### PR TITLE
Harden API flows and refresh dashboard UX

### DIFF
--- a/DEPLOY_GUIDE_FR.md
+++ b/DEPLOY_GUIDE_FR.md
@@ -15,6 +15,7 @@ Ce guide t'accompagne **pas à pas**.
    - **anon key** → `NEXT_PUBLIC_SUPABASE_ANON_KEY`
    - **service_role** → `SUPABASE_SERVICE_ROLE_KEY`
    - **JWT secret** → `SUPABASE_JWT_SECRET`
+   - **Video upload secret** → `VIDEO_UPLOAD_SECRET` (clé aléatoire > 32 caractères utilisée pour signer les uploads)
 2. Dans **SQL Editor**, colle le contenu de `supabase/schema.sql` et exécute.
 3. (Optionnel) Crée un **bucket** `videos` si tu veux stocker les vidéos.
 
@@ -46,7 +47,7 @@ Va sur http://localhost:3000
 
 ## 9) Notes sécurité & prod
 - `jobs`/`candidates` ont RLS permissif pour MVP. **À restreindre** par `org_id/user_id`.
-- Ajoute une **signature HMAC** pour le token mobile vidéo (cf. TODO dans `/api/upload/video`).
+- La signature HMAC pour l’upload vidéo est gérée côté serveur via `VIDEO_UPLOAD_SECRET`.
 - Active `redirectTo` du magic link vers `/dashboard`.
 - Ajoute monitoring (Logflare/Better Stack) et métriques.
 

--- a/app/api/jobs/[id]/route.ts
+++ b/app/api/jobs/[id]/route.ts
@@ -1,12 +1,20 @@
 import { NextRequest, NextResponse } from 'next/server'
+
 import { supabaseAdmin } from '@/lib/supabase/server'
+import { JobDetailsSchema } from '@/lib/types/jobs'
 
 export async function GET(_: NextRequest, { params }: { params: { id: string } }){
+  const jobId = Number(params.id)
+  if (Number.isNaN(jobId)) {
+    return NextResponse.json({ error: 'Invalid job id' }, { status: 400 })
+  }
+
   const admin = supabaseAdmin()
   const { data:job, error } = await admin
     .from('jobs')
-    .select('id,title,level,link,test_json,candidates(id,name,email,score,status,video_url,answers_json)')
-    .eq('id', params.id).single()
+    .select('id,title,level,link,created_at,test_json,candidates(id,name,email,score,status,video_url,answers_json)')
+    .eq('id', jobId).single()
   if(error) return NextResponse.json({error:error.message},{status:404})
-  return NextResponse.json({ job })
+  const safeJob = JobDetailsSchema.parse(job)
+  return NextResponse.json({ job: safeJob })
 }

--- a/app/api/jobs/create/route.ts
+++ b/app/api/jobs/create/route.ts
@@ -1,22 +1,66 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { supabaseAdmin } from '@/lib/supabase/server'
+import { randomBytes } from 'crypto'
+import { z } from 'zod'
+
 import { generateTestFromJD } from '@/lib/ai/claude'
+import { supabaseAdmin } from '@/lib/supabase/server'
+import { JobDetailsSchema } from '@/lib/types/jobs'
+import type { TestDefinition } from '@/lib/types/test'
+
+const CreateJobSchema = z.object({
+  title: z.string().min(2),
+  level: z.enum(['Junior', 'Intermédiaire', 'Senior']),
+  jd: z.string().min(20)
+})
+
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL?.replace(/\/$/, '') ?? 'https://ohframe.app'
+
+function generateSlug() {
+  return randomBytes(4).toString('hex')
+}
 
 export async function POST(req: NextRequest){
-  const body = await req.json()
-  const { title, level, jd } = body
-  if(!title || !level || !jd) return NextResponse.json({error:'Missing fields'}, {status:400})
+  let payload: unknown
+  try {
+    payload = await req.json()
+  } catch (error) {
+    return NextResponse.json({ error: 'Invalid JSON payload' }, { status: 400 })
+  }
+
+  const parsed = CreateJobSchema.safeParse(payload)
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: 'Invalid job payload', details: parsed.error.flatten() },
+      { status: 400 }
+    )
+  }
+
+  const { title, level, jd } = parsed.data
 
   // Generate questions via Claude
-  const test = await generateTestFromJD(jd, level)
+  let test: TestDefinition
+  try {
+    test = await generateTestFromJD(jd, level)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown Claude error'
+    return NextResponse.json({ error: message }, { status: 502 })
+  }
 
   // Persist job + questions
   const admin = supabaseAdmin()
-  const slug = Math.random().toString(36).slice(2,8)
-  const { data:job, error } = await admin.from('jobs').insert({
-    title, level, slug, link: `https://ohframe.app/t/${slug}`, jd, test_json: test
-  }).select().single()
+  const slug = generateSlug()
+  const link = `${SITE_URL}/t/${slug}`
+  const { data: job, error } = await admin.from('jobs').insert({
+    title,
+    level,
+    slug,
+    link,
+    jd,
+    test_json: test
+  }).select('id,title,level,link,created_at,test_json').single()
   if(error) return NextResponse.json({error: error.message}, {status:500})
 
-  return NextResponse.json({ job })
+  const safeJob = JobDetailsSchema.parse({ ...job, candidates: [] })
+
+  return NextResponse.json({ job: safeJob })
 }

--- a/app/api/jobs/list/route.ts
+++ b/app/api/jobs/list/route.ts
@@ -1,9 +1,16 @@
 import { NextResponse } from 'next/server'
+
 import { supabaseAdmin } from '@/lib/supabase/server'
+import { JobListItemSchema } from '@/lib/types/jobs'
 
 export async function GET(){
   const admin = supabaseAdmin()
-  const { data, error } = await admin.from('jobs').select('id,title,level,link,created_at,candidates(count)')
+  const { data, error } = await admin
+    .from('jobs')
+    .select('id,title,level,link,created_at,candidates(count)')
+    .order('created_at', { ascending: false })
+
   if(error) return NextResponse.json({error:error.message},{status:500})
-  return NextResponse.json({ jobs: data })
+  const jobs = JobListItemSchema.array().parse(data ?? [])
+  return NextResponse.json({ jobs })
 }

--- a/app/api/test/by-slug/[slug]/route.ts
+++ b/app/api/test/by-slug/[slug]/route.ts
@@ -1,24 +1,58 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { supabaseAdmin } from '@/lib/supabase/server'
+import { z } from 'zod'
 
-export async function GET(req: NextRequest, { params }: { params: { slug: string } }){
+import { supabaseAdmin } from '@/lib/supabase/server'
+import { TestDefinitionSchema } from '@/lib/types/test'
+
+const SubmitAnswersSchema = z.object({
+  candidate: z.string().min(1),
+  email: z.string().email(),
+  answers: z.unknown(),
+  score: z.number().min(0).max(100),
+  status: z.string().min(1),
+  videoUrl: z.string().url().optional()
+})
+
+export async function GET(_: NextRequest, { params }: { params: { slug: string } }){
   const admin = supabaseAdmin()
   const { data:job, error } = await admin.from('jobs').select('id,title,level,test_json').eq('slug', params.slug).single()
-  if(error) return NextResponse.json({error:'Not found'},{status:404})
+  if(error || !job?.test_json) return NextResponse.json({error:'Not found'},{status:404})
+
+  const test = TestDefinitionSchema.parse(job.test_json)
   // return minimal test definition
-  return NextResponse.json({ jobId: job.id, title: job.title, level: job.level, test: job.test_json })
+  return NextResponse.json({ jobId: job.id, title: job.title, level: job.level, test })
 }
 
 export async function POST(req: NextRequest, { params }: { params: { slug: string } }){
   // submit answers
-  const body = await req.json()
-  const { candidate, email, answers, score, status } = body
+  let payload: unknown
+  try {
+    payload = await req.json()
+  } catch (error) {
+    return NextResponse.json({ error: 'Invalid JSON payload' }, { status: 400 })
+  }
+
+  const parsed = SubmitAnswersSchema.safeParse(payload)
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: 'Invalid submission payload', details: parsed.error.flatten() },
+      { status: 400 }
+    )
+  }
+
+  const { candidate, email, answers, score, status, videoUrl } = parsed.data
   const admin = supabaseAdmin()
   // create candidate row
   const { data:job } = await admin.from('jobs').select('id').eq('slug', params.slug).single()
   if(!job) return NextResponse.json({error:'Invalid job'},{status:400})
   const { error } = await admin.from('candidates').insert({
-    job_id: job.id, name: candidate, email, score, status, answers_json: answers
+    job_id: job.id,
+    name: candidate,
+    email,
+    score,
+    status,
+    answers_json: answers,
+    video_url: videoUrl ?? null
   })
   if(error) return NextResponse.json({error:error.message},{status:500})
   return NextResponse.json({ ok: true })

--- a/app/api/upload/video/route.ts
+++ b/app/api/upload/video/route.ts
@@ -1,33 +1,127 @@
 import { NextRequest, NextResponse } from 'next/server'
-import formidable from 'formidable'
+import { createHmac, timingSafeEqual } from 'crypto'
+import { z } from 'zod'
+
 import { supabaseAdmin } from '@/lib/supabase/server'
-import { createReadStream } from 'fs'
-import { promisify } from 'util'
 
 export const dynamic = 'force-dynamic'
 export const runtime = 'nodejs'
 
-function parseForm(req: NextRequest): Promise<{ fields: any, files: any }>{
-  const form = formidable({ multiples: false })
-  return new Promise((resolve, reject) => {
-    // @ts-ignore
-    form.parse(req as any, (err: any, fields: any, files: any) => {
-      if (err) reject(err); else resolve({ fields, files })
-    })
-  })
+const MAX_VIDEO_SIZE = 200 * 1024 * 1024 // 200 MB
+const VIDEO_UPLOAD_SECRET = process.env.VIDEO_UPLOAD_SECRET
+
+const UploadTokenSchema = z.object({
+  jobId: z.number().int().nonnegative(),
+  candidateId: z.number().int().nonnegative(),
+  questionId: z.string().optional(),
+  exp: z.number().int().optional()
+})
+
+function verifyUploadToken(token: string) {
+  if (!VIDEO_UPLOAD_SECRET) {
+    throw new Error('Upload secret is not configured')
+  }
+
+  const [encodedPayload, signature] = token.split('.')
+  if (!encodedPayload || !signature) {
+    throw new Error('Malformed upload token')
+  }
+
+  let expectedSignature: string
+  try {
+    expectedSignature = createHmac('sha256', VIDEO_UPLOAD_SECRET).update(encodedPayload).digest('base64url')
+  } catch (error) {
+    throw new Error('Unable to sign upload token')
+  }
+
+  const signatureBuffer = Buffer.from(signature, 'base64url')
+  const expectedBuffer = Buffer.from(expectedSignature, 'base64url')
+  if (
+    signatureBuffer.length !== expectedBuffer.length ||
+    !timingSafeEqual(signatureBuffer, expectedBuffer)
+  ) {
+    throw new Error('Invalid upload token signature')
+  }
+
+  const payloadJson = Buffer.from(encodedPayload, 'base64url').toString('utf8')
+  let payload: unknown
+  try {
+    payload = JSON.parse(payloadJson)
+  } catch (error) {
+    throw new Error('Upload token payload is not valid JSON')
+  }
+
+  const parsed = UploadTokenSchema.parse(payload)
+  if (parsed.exp && parsed.exp * 1000 < Date.now()) {
+    throw new Error('Upload token has expired')
+  }
+
+  return parsed
 }
 
-export async function POST(req: any){
-  const { fields, files } = await parseForm(req)
-  const token = fields.token
-  if(!token) return NextResponse.json({error:'Missing token'},{status:400})
-  // TODO: verify token signature HMAC (server secret); decode job/candidate/question
+function sanitizeFileName(name: string) {
+  return name.replace(/[^a-zA-Z0-9._-]/g, '_') || 'recording.webm'
+}
 
-  const file = files.file
-  if(!file) return NextResponse.json({error:'No file'},{status:400})
+export async function POST(req: NextRequest){
+  let formData: FormData
+  try {
+    formData = await req.formData()
+  } catch (error) {
+    return NextResponse.json({ error: 'Invalid multipart form data' }, { status: 400 })
+  }
 
-  // In real app: upload to Supabase Storage or S3, link to candidate row
+  const token = formData.get('token')
+  if (typeof token !== 'string') {
+    return NextResponse.json({ error: 'Missing token' }, { status: 400 })
+  }
+
+  let tokenPayload
+  try {
+    tokenPayload = verifyUploadToken(token)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Invalid token'
+    return NextResponse.json({ error: message }, { status: 401 })
+  }
+
+  const file = formData.get('file')
+  if (!(file instanceof File)) {
+    return NextResponse.json({ error: 'No file provided' }, { status: 400 })
+  }
+
+  if (file.size === 0) {
+    return NextResponse.json({ error: 'Empty file' }, { status: 400 })
+  }
+
+  if (file.size > MAX_VIDEO_SIZE) {
+    return NextResponse.json({ error: 'File too large' }, { status: 413 })
+  }
+
+  const buffer = Buffer.from(await file.arrayBuffer())
+  const fileName = sanitizeFileName(file.name)
+  const storagePath = `${tokenPayload.jobId}/${tokenPayload.candidateId}/${Date.now()}-${fileName}`
+
   const admin = supabaseAdmin()
-  // Dummy OK
-  return NextResponse.json({ ok: true })
+  const { error: uploadError } = await admin.storage.from('videos').upload(storagePath, buffer, {
+    contentType: file.type || 'video/webm',
+    upsert: false
+  })
+  if (uploadError) {
+    return NextResponse.json({ error: uploadError.message }, { status: 500 })
+  }
+
+  const { data: publicData } = admin.storage.from('videos').getPublicUrl(storagePath)
+  const publicUrl = publicData?.publicUrl ?? null
+
+  const { error: updateError } = await admin
+    .from('candidates')
+    .update({ video_url: publicUrl })
+    .eq('id', tokenPayload.candidateId)
+    .eq('job_id', tokenPayload.jobId)
+
+  if (updateError) {
+    return NextResponse.json({ error: updateError.message }, { status: 500 })
+  }
+
+  return NextResponse.json({ ok: true, url: publicUrl })
 }

--- a/app/dashboard/CandidateModal.tsx
+++ b/app/dashboard/CandidateModal.tsx
@@ -1,45 +1,126 @@
 'use client'
-import { useEffect, useState } from 'react'
 
-export default function CandidateModal(){
-  const [open,setOpen] = useState(false)
-  const [data,setData] = useState<any>(null)
+import { useEffect, useMemo, useState } from 'react'
 
-  useEffect(()=>{
-    const onOpen = (e:any)=>{ setData(e.detail); setOpen(true) }
-    window.addEventListener('open-candidate', onOpen as any)
-    return ()=> window.removeEventListener('open-candidate', onOpen as any)
-  },[])
+import type { CandidateSummary, JobDetails } from '@/lib/types/jobs'
 
-  if(!open) return null
-  const { job, c } = data
+type CandidateEventDetail = { job: JobDetails; candidate: CandidateSummary }
+
+export default function CandidateModal() {
+  const [open, setOpen] = useState(false)
+  const [data, setData] = useState<CandidateEventDetail | null>(null)
+
+  useEffect(() => {
+    const onOpen = (event: Event) => {
+      const detail = (event as CustomEvent<CandidateEventDetail>).detail
+      setData(detail)
+      setOpen(true)
+    }
+
+    window.addEventListener('open-candidate', onOpen as EventListener)
+
+    return () => {
+      window.removeEventListener('open-candidate', onOpen as EventListener)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!open) return
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault()
+        closeModal()
+      }
+    }
+
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [open])
+
+  const closeModal = () => {
+    setOpen(false)
+    setData(null)
+  }
+
+  if (!open || !data) return null
+
+  const { job, candidate } = data
+  const candidateName = candidate.name?.trim() || 'Candidat inconnu'
+  const firstName = candidate.name?.split(/\s+/)[0] || 'candidat'
+  const score = typeof candidate.score === 'number' ? Math.round(candidate.score) : null
+  const scoreClass = score == null ? '' : score >= 80 ? 'ok' : score >= 65 ? 'mid' : 'bad'
+  const answers = useMemo(() => normaliseAnswers(candidate.answers_json), [candidate.answers_json])
+
+  const mailtoHref = useMemo(() => {
+    if (!candidate.email) return undefined
+    const subject = encodeURIComponent(`Entretien ${job.title}`)
+    const body = encodeURIComponent(
+      `Bonjour ${firstName},\n\nNous vous proposons un entretien de 30 minutes pour faire connaissance.\n\nCordialement,`
+    )
+    return `mailto:${candidate.email}?subject=${subject}&body=${body}`
+  }, [candidate.email, firstName, job.title])
 
   return (
-    <div style={{position:'fixed', inset:0, background:'rgba(16,12,8,.36)', display:'grid', placeItems:'center', padding:18}}>
-      <div className="card" style={{maxWidth:900, width:'96vw'}}>
-        <div style={{display:'flex', justifyContent:'space-between', alignItems:'center'}}>
-          <h3>{c.name} — {job.title}</h3>
-          <div style={{display:'flex', gap:8}}>
-            <a className="button" href={`mailto:${c.email}?subject=Entretien ${encodeURIComponent(job.title)}&body=Bonjour ${c.name.split(' ')[0]},`}>Contacter par mail</a>
-            <a className="button primary" onClick={()=> openInterview(c)}>Proposer un entretien</a>
-            <a className="button" onClick={()=> setOpen(false)}>Fermer</a>
+    <div style={{ position: 'fixed', inset: 0, background: 'rgba(16,12,8,.36)', display: 'grid', placeItems: 'center', padding: 18 }}>
+      <div className="card" style={{ maxWidth: 900, width: '96vw', maxHeight: '90vh', overflowY: 'auto' }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 12 }}>
+          <div>
+            <h3 style={{ margin: 0 }}>{candidateName} — {job.title}</h3>
+            <p className="muted" style={{ marginTop: 4 }}>{candidate.email ?? 'Email non renseigné'}</p>
+          </div>
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, justifyContent: 'flex-end' }}>
+            {mailtoHref && (
+              <a className="button" href={mailtoHref}>Contacter par mail</a>
+            )}
+            <button className="button primary" type="button" onClick={() => openInterview(job, candidate)}>
+              Proposer un entretien
+            </button>
+            <button className="button" type="button" onClick={closeModal}>
+              Fermer
+            </button>
           </div>
         </div>
-        <div style={{marginTop:12}}>
-          <p><strong>Score global :</strong> <span className={`score ${c.score>=80?'ok':c.score>=65?'mid':'bad'}`}>{c.score}</span> — {c.status}</p>
-          <div className="card" style={{marginTop:10}}>
+
+        <div style={{ marginTop: 12 }}>
+          <p>
+            <strong>Score global :</strong>{' '}
+            <span className={`score ${scoreClass}`}>{score ?? '—'}</span>{' '}
+            — {candidate.status ?? 'En revue'}
+          </p>
+          <div className="card" style={{ marginTop: 10 }}>
             <h4>Réponses & scores par question</h4>
-            <pre style={{whiteSpace:'pre-wrap', background:'var(--card)', border:'1px solid var(--ring)', padding:12, borderRadius:12, maxHeight:260, overflow:'auto'}}>
-{JSON.stringify(c.answers_json||{}, null, 2)}
-            </pre>
+            <pre
+              style={{
+                whiteSpace: 'pre-wrap',
+                background: 'var(--card)',
+                border: '1px solid var(--ring)',
+                padding: 12,
+                borderRadius: 12,
+                maxHeight: 260,
+                overflow: 'auto'
+              }}
+            >{JSON.stringify(answers, null, 2)}</pre>
           </div>
         </div>
       </div>
     </div>
-  )
+    )
+  }
+
+function openInterview(job: JobDetails, candidate: CandidateSummary) {
+  const evt = new CustomEvent('open-interview', { detail: { job, candidate } })
+  window.dispatchEvent(evt)
 }
 
-function openInterview(c:any){
-  const evt = new CustomEvent('open-interview', { detail: { c } })
-  window.dispatchEvent(evt)
+function normaliseAnswers(raw: unknown) {
+  if (raw == null) return {}
+  if (typeof raw === 'string') {
+    try {
+      return JSON.parse(raw)
+    } catch (error) {
+      return { raw }
+    }
+  }
+  return raw
 }

--- a/app/dashboard/InterviewModal.tsx
+++ b/app/dashboard/InterviewModal.tsx
@@ -1,36 +1,122 @@
 'use client'
-import { useEffect, useState } from 'react'
 
-export default function InterviewModal(){
-  const [open,setOpen] = useState(false)
-  const [c,setC] = useState<any>(null)
-  const [d,setD] = useState('')
-  const [t,setT] = useState('')
-  const [m,setM] = useState('')
+import { useEffect, useMemo, useState } from 'react'
 
-  useEffect(()=>{
-    const onOpen = (e:any)=>{ setC(e.detail.c); setOpen(true); setM(`Bonjour ${e.detail.c.name},\n\nNous vous proposons un entretien (30 min). Merci de confirmer.\n\nCordialement,`) }
-    window.addEventListener('open-interview', onOpen as any)
-    return ()=> window.removeEventListener('open-interview', onOpen as any)
-  },[])
+import type { CandidateSummary, JobDetails } from '@/lib/types/jobs'
 
-  if(!open) return null
+type InterviewEventDetail = { candidate: CandidateSummary; job?: JobDetails }
+
+export default function InterviewModal() {
+  const [open, setOpen] = useState(false)
+  const [candidate, setCandidate] = useState<CandidateSummary | null>(null)
+  const [job, setJob] = useState<JobDetails | null>(null)
+  const [date, setDate] = useState('')
+  const [time, setTime] = useState('')
+  const [message, setMessage] = useState('')
+  const [feedback, setFeedback] = useState<string | null>(null)
+
+  useEffect(() => {
+    const onOpen = (event: Event) => {
+      const detail = (event as CustomEvent<InterviewEventDetail>).detail
+      setCandidate(detail.candidate)
+      setJob(detail.job ?? null)
+      setDate('')
+      setTime('')
+      setFeedback(null)
+      setMessage(buildDefaultMessage(detail.candidate, detail.job))
+      setOpen(true)
+    }
+
+    window.addEventListener('open-interview', onOpen as EventListener)
+    return () => window.removeEventListener('open-interview', onOpen as EventListener)
+  }, [])
+
+  useEffect(() => {
+    if (!open) return
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault()
+        handleClose()
+      }
+    }
+
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [open])
+
+  const interviewDateLabel = useMemo(() => formatInterviewDate(date, time), [date, time])
+
+  const mailtoHref = useMemo(() => {
+    if (!candidate?.email || !interviewDateLabel) return undefined
+    const subject = encodeURIComponent(`Invitation entretien ${job?.title ?? ''}`.trim())
+    const body = encodeURIComponent(`${message}\n\n📅 ${interviewDateLabel}`)
+    return `mailto:${candidate.email}?subject=${subject}&body=${body}`
+  }, [candidate?.email, interviewDateLabel, job?.title, message])
+
+  const canSend = Boolean(mailtoHref)
+
+  const handleSend = () => {
+    if (!mailtoHref) return
+    setFeedback('Invitation générée dans votre client mail.')
+    window.location.href = mailtoHref
+  }
+
+  const handleClose = () => {
+    setOpen(false)
+  }
+
+  if (!open || !candidate) return null
+
+  const candidateName = candidate.name ?? 'candidat'
+
   return (
-    <div style={{position:'fixed', inset:0, background:'rgba(16,12,8,.36)', display:'grid', placeItems:'center', padding:18}}>
-      <div className="card" style={{maxWidth:680, width:'96vw'}}>
-        <div style={{display:'flex', justifyContent:'space-between', alignItems:'center'}}>
-          <h3>Proposer un entretien</h3>
-          <a className="button" onClick={()=> setOpen(false)}>Fermer</a>
-        </div>
-        <div style={{display:'grid', gap:10, marginTop:10}}>
-          <div style={{display:'flex', gap:10}}>
-            <input type="date" value={d} onChange={e=>setD(e.target.value)} />
-            <input type="time" value={t} onChange={e=>setT(e.target.value)} />
+    <div style={{ position: 'fixed', inset: 0, background: 'rgba(16,12,8,.36)', display: 'grid', placeItems: 'center', padding: 18 }}>
+      <div className="card" style={{ maxWidth: 680, width: '96vw', maxHeight: '90vh', overflowY: 'auto' }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+          <div>
+            <h3 style={{ margin: 0 }}>Proposer un entretien</h3>
+            <p className="muted" style={{ marginTop: 4 }}>
+              {candidateName}
+              {job ? ` — ${job.title}` : ''}
+            </p>
           </div>
-          <textarea rows={6} value={m} onChange={e=>setM(e.target.value)} />
-          <a className="button primary" onClick={()=> { alert('Invitation envoyée'); setOpen(false) }}>Envoyer l'invitation</a>
+          <button className="button" type="button" onClick={handleClose}>
+            Fermer
+          </button>
+        </div>
+
+        <div style={{ display: 'grid', gap: 10, marginTop: 10 }}>
+          <div style={{ display: 'flex', gap: 10, flexWrap: 'wrap' }}>
+            <input type="date" value={date} onChange={(event) => setDate(event.target.value)} />
+            <input type="time" value={time} onChange={(event) => setTime(event.target.value)} />
+          </div>
+          <textarea rows={6} value={message} onChange={(event) => setMessage(event.target.value)} />
+          <button className="button primary" type="button" onClick={handleSend} disabled={!canSend}>
+            Envoyer l'invitation
+          </button>
+          {feedback && <p className="muted">{feedback}</p>}
+          {!candidate.email && <p className="muted">Ajoutez l’email du candidat pour générer l’invitation.</p>}
+          {candidate.email && !interviewDateLabel && <p className="muted">Sélectionnez une date et une heure.</p>}
         </div>
       </div>
     </div>
   )
+}
+
+function buildDefaultMessage(candidate: CandidateSummary, job?: JobDetails | null) {
+  const firstName = candidate.name?.split(/\s+/)[0] ?? 'Bonjour'
+  const jobLabel = job ? ` pour le poste ${job.title}` : ''
+  return `Bonjour ${firstName},\n\nNous vous proposons un entretien de 30 minutes${jobLabel}. Merci de nous confirmer votre disponibilité.\n\nCordialement,`
+}
+
+function formatInterviewDate(date: string, time: string) {
+  if (!date || !time) return null
+  const isoString = `${date}T${time}`
+  const parsed = new Date(isoString)
+  if (Number.isNaN(parsed.getTime())) return null
+  return new Intl.DateTimeFormat('fr-FR', {
+    dateStyle: 'full',
+    timeStyle: 'short'
+  }).format(parsed)
 }

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,74 +1,259 @@
 'use client'
-import { useEffect, useState } from 'react'
 
-type Job = { id:string; title:string; level:string; link:string; created_at:string; candidates?: { count: number }[] }
-type JobsRes = { jobs: Job[] }
+import { useEffect, useMemo, useState } from 'react'
 
-export default function Dashboard(){
-  const [jobs,setJobs] = useState<Job[]>([])
-  const [open,setOpen] = useState(false)
-  const [selected,setSelected] = useState<any>(null)
-  const [details,setDetails] = useState<any>(null)
+import CandidateModal from './CandidateModal'
+import InterviewModal from './InterviewModal'
+import type { CandidateSummary, JobDetails, JobListItem } from '@/lib/types/jobs'
 
-  useEffect(()=>{
-    fetch('/api/jobs/list').then(r=>r.json()).then((d:JobsRes)=> setJobs(d.jobs||[]))
-  },[])
+type JobsResponse = { jobs: JobListItem[] }
 
-  const load = async (id:string)=>{
-    setSelected(id)
-    const j = await fetch('/api/jobs/'+id).then(r=>r.json())
-    setDetails(j.job)
+type JobDetailsResponse = { job: JobDetails }
+
+export default function Dashboard() {
+  const [jobs, setJobs] = useState<JobListItem[]>([])
+  const [jobsOpen, setJobsOpen] = useState(true)
+  const [jobsLoading, setJobsLoading] = useState(false)
+  const [jobsError, setJobsError] = useState<string | null>(null)
+
+  const [selectedJobId, setSelectedJobId] = useState<number | null>(null)
+  const [jobDetails, setJobDetails] = useState<JobDetails | null>(null)
+  const [detailsLoading, setDetailsLoading] = useState(false)
+  const [detailsError, setDetailsError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let active = true
+    const controller = new AbortController()
+
+    async function fetchJobs() {
+      setJobsLoading(true)
+      setJobsError(null)
+
+      try {
+        const response = await fetch('/api/jobs/list', {
+          signal: controller.signal,
+          cache: 'no-store'
+        })
+
+        if (!response.ok) {
+          throw new Error(await response.text())
+        }
+
+        const payload: JobsResponse = await response.json()
+        if (!active) return
+
+        setJobs(payload.jobs ?? [])
+        if ((payload.jobs?.length ?? 0) > 0) {
+          setSelectedJobId((current) => current ?? payload.jobs[0].id)
+        }
+      } catch (error) {
+        if (!active) return
+        if ((error as Error).name === 'AbortError') return
+        setJobsError('Impossible de charger vos annonces pour le moment.')
+      } finally {
+        if (active) {
+          setJobsLoading(false)
+        }
+      }
+    }
+
+    fetchJobs()
+
+    return () => {
+      active = false
+      controller.abort()
+    }
+  }, [])
+
+  useEffect(() => {
+    if (selectedJobId == null) {
+      setJobDetails(null)
+      return
+    }
+
+    let active = true
+    const controller = new AbortController()
+
+    async function fetchJobDetails(jobId: number) {
+      setDetailsLoading(true)
+      setDetailsError(null)
+
+      try {
+        const response = await fetch(`/api/jobs/${jobId}`, {
+          signal: controller.signal,
+          cache: 'no-store'
+        })
+
+        if (!response.ok) {
+          throw new Error(await response.text())
+        }
+
+        const payload: JobDetailsResponse = await response.json()
+        if (!active) return
+
+        setJobDetails(payload.job)
+      } catch (error) {
+        if (!active) return
+        if ((error as Error).name === 'AbortError') return
+        setDetailsError('Impossible de charger les détails de l’annonce sélectionnée.')
+        setJobDetails(null)
+      } finally {
+        if (active) {
+          setDetailsLoading(false)
+        }
+      }
+    }
+
+    fetchJobDetails(selectedJobId)
+
+    return () => {
+      active = false
+      controller.abort()
+    }
+  }, [selectedJobId])
+
+  const selectedJobCandidates = useMemo(
+    () => jobDetails?.candidates ?? [],
+    [jobDetails]
+  )
+
+  const handleCandidateClick = (job: JobDetails, candidate: CandidateSummary) => {
+    const evt = new CustomEvent('open-candidate', { detail: { job, candidate } })
+    window.dispatchEvent(evt)
   }
 
   return (
     <main className="container">
-      <div className="card" style={{display:'grid', gridTemplateColumns:'260px 1fr', gap:16}}>
+      <div className="card" style={{ display: 'grid', gridTemplateColumns: '260px 1fr', gap: 16 }}>
         <aside>
-          <a className="button" onClick={()=> setOpen(!open)}>📄 Mes annonces</a>
-          {open && (
-            <div style={{marginTop:8, borderLeft:'1px solid var(--ring)', paddingLeft:8}}>
-              {jobs.map(j=>(
-                <div key={j.id} style={{display:'flex', justifyContent:'space-between', padding:'6px 8px', cursor:'pointer'}}
-                     onClick={()=> load(j.id)}>
-                  <span>{j.title}</span>
-                  <span className="badge">{j.candidates?.[0]?.count ?? 0}</span>
-                </div>
-              ))}
+          <button
+            className="button"
+            type="button"
+            onClick={() => setJobsOpen((value) => !value)}
+          >
+            📄 {jobsOpen ? 'Masquer les annonces' : 'Mes annonces'}
+          </button>
+
+          {jobsOpen && (
+            <div style={{ marginTop: 8, borderLeft: '1px solid var(--ring)', paddingLeft: 8 }}>
+              {jobsLoading && <p className="muted">Chargement…</p>}
+              {jobsError && <p className="muted">{jobsError}</p>}
+
+              {!jobsLoading && !jobsError && jobs.length === 0 && (
+                <p className="muted">Créez votre première annonce pour voir les candidats ici.</p>
+              )}
+
+              {jobs.map((job) => {
+                const isSelected = job.id === selectedJobId
+                const count = job.candidates?.[0]?.count ?? 0
+
+                return (
+                  <button
+                    key={job.id}
+                    type="button"
+                    onClick={() => setSelectedJobId(job.id)}
+                    style={{
+                      display: 'flex',
+                      justifyContent: 'space-between',
+                      alignItems: 'center',
+                      padding: '6px 8px',
+                      cursor: 'pointer',
+                      width: '100%',
+                      border: 'none',
+                      background: isSelected ? 'rgba(218,119,86,0.12)' : 'transparent',
+                      borderRadius: 10,
+                      color: 'inherit'
+                    }}
+                  >
+                    <span style={{ textAlign: 'left' }}>{job.title}</span>
+                    <span className="badge">{count}</span>
+                  </button>
+                )
+              })}
             </div>
           )}
         </aside>
+
         <section>
-          {!details ? <p className="muted">Sélectionnez une annonce…</p> : (
-            <div style={{display:'grid', gap:12}}>
+          {detailsLoading && <p className="muted">Chargement des détails…</p>}
+          {detailsError && <p className="muted">{detailsError}</p>}
+
+          {!detailsLoading && !detailsError && !jobDetails && (
+            <p className="muted">Sélectionnez une annonce pour consulter ses résultats.</p>
+          )}
+
+          {!detailsLoading && !detailsError && jobDetails && (
+            <div style={{ display: 'grid', gap: 12 }}>
               <div className="card">
-                <h3>{details.title} <span className="badge">{details.level}</span></h3>
-                <div style={{display:'flex', gap:10, flexWrap:'wrap'}}>
-                  <div className="badge">URL courte : <strong>{details.link}</strong></div>
-                  <div className="badge">Candidatures : <strong>{details.candidates?.length||0}</strong></div>
+                <h3>
+                  {jobDetails.title} <span className="badge">{jobDetails.level}</span>
+                </h3>
+                <div style={{ display: 'flex', gap: 10, flexWrap: 'wrap', alignItems: 'center' }}>
+                  <a className="badge" href={jobDetails.link} target="_blank" rel="noreferrer">
+                    URL courte : <strong>{jobDetails.link}</strong>
+                  </a>
+                  <div className="badge">
+                    Candidatures : <strong>{selectedJobCandidates.length}</strong>
+                  </div>
                 </div>
               </div>
+
               <div className="card">
                 <h3>Candidats</h3>
-                <table><thead><tr><th>Nom</th><th>Email</th><th>Score</th><th>Statut</th><th>Vidéo</th></tr></thead><tbody>
-                  {details.candidates?.map((c:any)=>(
-                    <tr key={c.id} onClick={()=> openCandidate(details, c)} style={{cursor:'pointer'}}>
-                      <td>{c.name}</td><td><a href={`mailto:${c.email}`}>{c.email}</a></td>
-                      <td>{scoreBadge(c.score)}</td><td>{c.status}</td><td>{c.video_url? '🎥':'—'}</td>
-                    </tr>
-                  ))}
-                </tbody></table>
+                {selectedJobCandidates.length === 0 ? (
+                  <p className="muted">Aucun candidat n’a encore terminé le test.</p>
+                ) : (
+                  <table>
+                    <thead>
+                      <tr>
+                        <th>Nom</th>
+                        <th>Email</th>
+                        <th>Score</th>
+                        <th>Statut</th>
+                        <th>Vidéo</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {selectedJobCandidates.map((candidate) => (
+                        <tr
+                          key={candidate.id}
+                          onClick={() => handleCandidateClick(jobDetails, candidate)}
+                          style={{ cursor: 'pointer' }}
+                        >
+                          <td>{candidate.name ?? '—'}</td>
+                          <td>
+                            {candidate.email ? (
+                              <a href={`mailto:${candidate.email}`}>{candidate.email}</a>
+                            ) : (
+                              '—'
+                            )}
+                          </td>
+                          <td>{renderScoreBadge(candidate.score)}</td>
+                          <td>{candidate.status ?? 'En revue'}</td>
+                          <td>{candidate.video_url ? '🎥' : '—'}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                )}
               </div>
             </div>
           )}
         </section>
       </div>
+
+      <CandidateModal />
+      <InterviewModal />
     </main>
   )
 }
 
-function scoreBadge(n:number){ const cls = n>=80? 'ok' : n>=65? 'mid' : 'bad'; return <span className={`score ${cls}`}>{n}</span> }
+function renderScoreBadge(score: number | null | undefined) {
+  if (typeof score !== 'number' || Number.isNaN(score)) {
+    return <span className="score">—</span>
+  }
 
-function openCandidate(job:any, c:any){
-  const evt = new CustomEvent('open-candidate', { detail: { job, c } })
-  window.dispatchEvent(evt)
+  const rounded = Math.round(score)
+  const cls = rounded >= 80 ? 'ok' : rounded >= 65 ? 'mid' : 'bad'
+  return <span className={`score ${cls}`}>{rounded}</span>
 }

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,28 +1,83 @@
 'use client'
-import { useState } from 'react'
+
+import { useMemo, useState, type FormEvent } from 'react'
 import { createClient } from '@supabase/supabase-js'
 
-export default function Login(){
-  const [email,setEmail] = useState('')
-  const [sent,setSent] = useState(false)
-  const supabase = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!, { auth: { persistSession: true } })
+type AuthStatus = 'idle' | 'loading' | 'sent' | 'error'
 
-  const send = async (e: any)=>{
-    e.preventDefault()
-    const { error } = await supabase.auth.signInWithOtp({ email, options: { emailRedirectTo: `${process.env.NEXT_PUBLIC_SITE_URL}/dashboard` } })
-    if(error) alert(error.message); else setSent(true)
+export default function Login() {
+  const [email, setEmail] = useState('')
+  const [status, setStatus] = useState<AuthStatus>('idle')
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+
+  const supabase = useMemo(() => {
+    const url = process.env.NEXT_PUBLIC_SUPABASE_URL
+    const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+    if (!url || !anonKey) {
+      console.error('Supabase environment variables are missing')
+      return null
+    }
+    return createClient(url, anonKey, { auth: { persistSession: true } })
+  }, [])
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    if (status === 'loading') return
+
+    if (!supabase) {
+      setStatus('error')
+      setErrorMessage('Configuration Supabase manquante. Merci de contacter un administrateur.')
+      return
+    }
+
+    setStatus('loading')
+    setErrorMessage(null)
+
+    const redirectBase = process.env.NEXT_PUBLIC_SITE_URL?.replace(/\/$/, '')
+    const { error } = await supabase.auth.signInWithOtp({
+      email,
+      options: redirectBase ? { emailRedirectTo: `${redirectBase}/dashboard` } : undefined
+    })
+
+    if (error) {
+      setStatus('error')
+      setErrorMessage(error.message)
+      return
+    }
+
+    setStatus('sent')
   }
 
   return (
     <main className="container">
-      <div className="card" style={{maxWidth:520, margin:'40px auto'}}>
-        <h2>Connexion par lien magique</h2>
-        {!sent ? (
-          <form onSubmit={send} style={{display:'grid', gap:10}}>
-            <input type="email" placeholder="Email pro" value={email} onChange={e=>setEmail(e.target.value)} required/>
-            <button className="button primary" type="submit">Envoyer le lien</button>
+      <div className="card" style={{ maxWidth: 520, margin: '40px auto', display: 'grid', gap: 16 }}>
+        <div>
+          <h2 style={{ marginBottom: 8 }}>Connexion par lien magique</h2>
+          <p className="muted" style={{ margin: 0 }}>
+            Renseignez votre email professionnel pour recevoir un lien sécurisé.
+          </p>
+        </div>
+        {status !== 'sent' ? (
+          <form onSubmit={handleSubmit} style={{ display: 'grid', gap: 12 }}>
+            <label style={{ display: 'grid', gap: 6 }}>
+              <span>Email professionnel</span>
+              <input
+                type="email"
+                placeholder="prenom@entreprise.com"
+                value={email}
+                onChange={(event) => setEmail(event.target.value)}
+                autoComplete="email"
+                required
+              />
+            </label>
+            {errorMessage && <p className="muted" style={{ color: '#8d2d2d' }}>{errorMessage}</p>}
+            <button className="button primary" type="submit" disabled={status === 'loading'}>
+              {status === 'loading' ? 'Envoi…' : 'Envoyer le lien'}
+            </button>
           </form>
-        ) : <p>Vérifiez votre boite mail et cliquez sur le lien pour accéder au dashboard.</p>}
+        ) : (
+          <p>Vérifiez votre boîte mail et cliquez sur le lien pour accéder au dashboard.</p>
+        )}
       </div>
     </main>
   )

--- a/lib/ai/claude.ts
+++ b/lib/ai/claude.ts
@@ -1,30 +1,64 @@
-export async function generateTestFromJD(jdText: string, seniority: 'Junior'|'Intermédiaire'|'Senior'){
-  // Anthropic Claude 3.x style REST call
-  const res = await fetch('https://api.anthropic.com/v1/messages', {
-    method:'POST',
+import { TestDefinitionSchema, type TestDefinition } from '@/lib/types/test'
+
+type AnthropicContentBlock = { type: string; text?: string }
+type AnthropicResponse = { content?: AnthropicContentBlock[] }
+
+const ANTHROPIC_ENDPOINT = process.env.ANTHROPIC_API_URL ?? 'https://api.anthropic.com/v1/messages'
+const ANTHROPIC_VERSION = '2023-06-01'
+
+export async function generateTestFromJD(
+  jdText: string,
+  seniority: 'Junior' | 'Intermédiaire' | 'Senior'
+): Promise<TestDefinition> {
+  const apiKey = process.env.ANTHROPIC_API_KEY
+  if (!apiKey) {
+    throw new Error('Anthropic API key is not configured')
+  }
+
+  const response = await fetch(ANTHROPIC_ENDPOINT, {
+    method: 'POST',
     headers: {
-      'content-type':'application/json',
-      'x-api-key': process.env.ANTHROPIC_API_KEY!,
-      'anthropic-version':'2023-06-01'
+      'content-type': 'application/json',
+      'x-api-key': apiKey,
+      'anthropic-version': ANTHROPIC_VERSION
     },
     body: JSON.stringify({
       model: 'claude-3-5-sonnet-latest',
       max_tokens: 2000,
       temperature: 0.3,
       messages: [
-        { role:'user', content: buildPrompt(jdText, seniority) }
+        { role: 'user', content: [{ type: 'text', text: buildPrompt(jdText, seniority) }] }
       ]
-    })
+    }),
+    signal: AbortSignal.timeout(30_000)
   })
-  if(!res.ok) throw new Error('Claude API error: '+res.statusText)
-  const data = await res.json()
-  const text = data?.content?.[0]?.text || ''
-  return JSON.parse(text)
+
+  if (!response.ok) {
+    const errorBody = await response.text()
+    throw new Error(`Claude API error (${response.status}): ${errorBody}`)
+  }
+
+  const data = (await response.json()) as AnthropicResponse
+  const textBlock = data.content?.find((block) => block.type === 'text')?.text
+
+  if (!textBlock) {
+    throw new Error('Claude API response did not contain text content')
+  }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(textBlock)
+  } catch (error) {
+    throw new Error('Claude API response was not valid JSON')
+  }
+
+  return TestDefinitionSchema.parse(parsed)
 }
 
-function buildPrompt(jd: string, seniority: string){
+function buildPrompt(jd: string, seniority: string) {
   return `You are an assessment designer. Create a 25-minute pre-interview test tailored to the job description and seniority.
 Return strict JSON with keys: questions (array of 6 objects: id,type,title,hint,choices?,variants:10 distinct versions per question), scoring (rubric per question), antiCheat (rules).
+Do not include markdown or prose outside of the JSON object.
 Job description:
 ${jd}
 Seniority: ${seniority}.`

--- a/lib/types/jobs.ts
+++ b/lib/types/jobs.ts
@@ -1,0 +1,30 @@
+import { z } from 'zod'
+import { TestDefinitionSchema } from './test'
+
+export const CandidateSummarySchema = z.object({
+  id: z.number(),
+  name: z.string().nullable(),
+  email: z.string().email().optional().nullable(),
+  score: z.number().min(0).max(100).optional().nullable(),
+  status: z.string().optional().nullable(),
+  video_url: z.string().url().optional().nullable(),
+  answers_json: z.unknown().optional().nullable()
+})
+
+export const JobListItemSchema = z.object({
+  id: z.number(),
+  title: z.string(),
+  level: z.string(),
+  link: z.string(),
+  created_at: z.string(),
+  candidates: z.array(z.object({ count: z.number() })).optional()
+})
+
+export const JobDetailsSchema = JobListItemSchema.extend({
+  test_json: TestDefinitionSchema.nullable().optional(),
+  candidates: z.array(CandidateSummarySchema).optional().nullable()
+})
+
+export type CandidateSummary = z.infer<typeof CandidateSummarySchema>
+export type JobListItem = z.infer<typeof JobListItemSchema>
+export type JobDetails = z.infer<typeof JobDetailsSchema>

--- a/lib/types/test.ts
+++ b/lib/types/test.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod'
+
+export const TestQuestionSchema = z.object({
+  id: z.string().min(1),
+  type: z.string().min(1),
+  title: z.string().min(1),
+  hint: z.string().optional(),
+  choices: z.array(z.string().min(1)).optional(),
+  variants: z.array(z.string().min(1)).min(1)
+})
+
+export const TestDefinitionSchema = z.object({
+  questions: z.array(TestQuestionSchema).min(1),
+  scoring: z.record(z.string(), z.unknown()),
+  antiCheat: z.union([
+    z.array(z.string().min(1)),
+    z.record(z.string(), z.unknown())
+  ])
+})
+
+export type TestQuestion = z.infer<typeof TestQuestionSchema>
+export type TestDefinition = z.infer<typeof TestDefinitionSchema>

--- a/package.json
+++ b/package.json
@@ -19,8 +19,7 @@
     "zod": "3.23.8",
     "stripe": "16.6.0",
     "jsonwebtoken": "9.0.2",
-    "uuid": "9.0.1",
-    "formidable": "3.5.1"
+    "uuid": "9.0.1"
   },
   "devDependencies": {
     "@types/jsonwebtoken": "9.0.6",


### PR DESCRIPTION
## Summary
- validate job and test payloads with shared Zod schemas and harden Claude/test generation error handling
- secure the video upload endpoint with HMAC tokens, Supabase Storage persistence and document the required secret
- modernize the dashboard and login flows with richer UX plus reusable modals for candidate review and interview scheduling

## Testing
- npm run lint *(fails: dependencies unavailable because npm registry access is blocked in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d12d9e5c388329af4b507983a14c55